### PR TITLE
Update CloudLink Extension

### DIFF
--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -492,7 +492,7 @@ const menuItems = [
     },
     {
         name: 'CloudLink',
-        extensionId: 'https://mikedev101.github.io/cloudlink/scratch/cloudlink_penguinmod_0.1.0.js',
+        extensionId: 'https://mikedev101.github.io/cloudlink/scratch/cloudlink_penguinmod.js',
         tags: ['penguinmod', 'turbowarp'],
         insetIconURL: cloudlinkIcon,
         iconURL: 'https://extensions.turbowarp.org/images/cloudlink.svg',

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -492,14 +492,14 @@ const menuItems = [
     },
     {
         name: 'CloudLink',
-        extensionId: 'https://extensions.turbowarp.org/cloudlink.js',
-        tags: ['turbowarp'],
+        extensionId: 'https://mikedev101.github.io/cloudlink/scratch/cloudlink_penguinmod_0.1.0.js',
+        tags: ['penguinmod', 'turbowarp'],
         insetIconURL: cloudlinkIcon,
         iconURL: 'https://extensions.turbowarp.org/images/cloudlink.svg',
-        description: 'A cool extension to interact with webservers',
+        description: 'A powerful websocket extension.',
         featured: true,
-        extDeveloper: 'MikeDev',
-        internetConnectionRequired: false
+        extDeveloper: 'MikeDev101',
+        internetConnectionRequired: true
     },
     {
         name: 'LZ Compress',


### PR DESCRIPTION
This synchronizes the CloudLink extension to the latest upstream version directly from [MikeDev101/cloudlink](https://github.com/mikedev101/cloudlink). 