### PR TITLE
Fix pause button title in controls.jsx

### DIFF
--- a/src/components/controls/controls.jsx
+++ b/src/components/controls/controls.jsx
@@ -56,7 +56,7 @@ const Controls = function (props) {
             />
             <PauseButton
                 paused={paused}
-                title={intl.formatMessage(messages.goTitle)}
+                title={intl.formatMessage(messages.pauseTitle)}
                 onClick={onPauseButtonClick}
             />
             <StopAll


### PR DESCRIPTION
Pause button title now correctly displays "Pause" instead of "Go"
