### PR TITLE
Allow loading from pen-group repo.

### DIFF
--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -37,6 +37,7 @@ const TRUSTED_LOADEXT_ORIGINS = [
     'https://studio.penguinmod.com', // for development
     'https://extensions.penguinmod.com',
     'https://sharkpools-extensions.vercel.app',
+    'https://pen-group.github.io',
 ];
 
 class ExtensionLibrary extends React.PureComponent {


### PR DESCRIPTION
### Resolves
Nothing except future convenience.

### Proposed Changes
Allow loading from the pen-group repo
Contains beta versions of pen+ and in the future will contain various addons.

### Reason for Changes
It would be epic, and allow for me to post about the public beta in the penguinmod discord.

### Test Coverage
This should be it judging by this is the only place in the organization that sharkpool's repo is referenced in an allow list.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [x] Firefox 
 * [x] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [x] Chrome
 
iPad
* [x] Safari

Android Tablet
* [x] Chrome
