### PR TITLE
Error report now only appears when DropDownDiv not visible

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -425,7 +425,7 @@ class Blocks extends React.Component {
         const targetBlock = this.workspace.getBlockById(data.id);
         if (!targetBlock) return; // this happens when we switch sprites
         this.workspace.glowBlock(data.id, false);
-        this.workspace.reportValue(data.id, data.value, true);
+        if (!this.ScratchBlocks.DropDownDiv.isVisible()) this.workspace.reportValue(data.id, data.value, true);
         this.workspace.errorStack(data.id, true);
     }
     getToolboxXML () {


### PR DESCRIPTION
### Resolves

- Fixes #53.

### Proposed Changes

Error report now only appears when DropDownDiv not visible.

### Reason for Changes

It allows universal custom report block or advanced DropDownDiv usage.

### Test Coverage

N/A

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [x] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome

Note: Tests not required for this pull request
