### PR TITLE
Fix Packager opening twice

### DIFF
--- a/src/lib/tw-packager-integration-hoc.jsx
+++ b/src/lib/tw-packager-integration-hoc.jsx
@@ -23,7 +23,6 @@ const PackagerIntegrationHOC = function (WrappedComponent) {
         handleClickPackager() {
             if (this.props.canOpenPackager) {
                 window.open(`${PACKAGER_URL}/?import_from=${location.origin}`);
-                window.open(`${PACKAGER_URL}/?import_from=${location.origin}`);
             }
         }
         handleMessage(e) {


### PR DESCRIPTION
### Resolves

_https://github.com/PenguinMod/PenguinMod-Vm/issues/51_

### Proposed Changes

_Remove the second open call._

### Reason for Changes

_So the packager wont open twice._

### Test Coverage

_I haven't tested it, but it should work._

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [X] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [X] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
