### PR TITLE
dont use jwklong.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-scratch-gui modified for use in [TurboWarp](https://turbowarp.org/) then modified for use in [PenguinMod](https://jwklong.github.io/penguinmod.github.io) 😀
+scratch-gui modified for use in [TurboWarp](https://turbowarp.org/) then modified for use in [PenguinMod](https://penguinmod.com) 😀
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/PenguinMod/penguinmod.github.io/)
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-scratch-gui modified for use in [TurboWarp](https://turbowarp.org/) then modified for use in [PenguinMod](https://penguinmod.com) 😀
+scratch-gui modified for use in [TurboWarp](https://turbowarp.org/) then modified for use in [PenguinMod](https://studio.penguinmod.com) 😀
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/PenguinMod/penguinmod.github.io/)
 ## Setup
 

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -147,7 +147,7 @@ const PromptComponent = props => (
                         values={{
                             packager: (
                                 <a
-                                    href="https://jwklong.github.io/penguinmod.github.io/PenguinMod-Packager"
+                                    href="https://penguinmod.com/PenguinMod-Packager"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >

--- a/src/components/prompt/prompt.jsx
+++ b/src/components/prompt/prompt.jsx
@@ -147,7 +147,7 @@ const PromptComponent = props => (
                         values={{
                             packager: (
                                 <a
-                                    href="https://penguinmod.com/PenguinMod-Packager"
+                                    href="https://studio.penguinmod.com/PenguinMod-Packager"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >

--- a/src/components/tw-description/description.jsx
+++ b/src/components/tw-description/description.jsx
@@ -228,7 +228,7 @@ class Renderer {
         if (/^\d{6,}$/.test(id)) {
             return (
                 <a
-                    href={`https://jwklong.github.io/penguinmod.github.io/#${id}`}
+                    href={`https://penguinmod.com/#${id}`}
                 >
                     {`#${id}`}
                 </a>

--- a/src/components/tw-description/description.jsx
+++ b/src/components/tw-description/description.jsx
@@ -228,7 +228,7 @@ class Renderer {
         if (/^\d{6,}$/.test(id)) {
             return (
                 <a
-                    href={`https://penguinmod.com/#${id}`}
+                    href={`https://studio.penguinmod.com/#${id}`}
                 >
                     {`#${id}`}
                 </a>

--- a/src/components/tw-studioview/studioview.js
+++ b/src/components/tw-studioview/studioview.js
@@ -307,7 +307,7 @@ StudioView.THUMBNAIL_SRC = 'https://projects.penguinmod.com/api/v1/projects/getp
 
 // The URL for project pages.
 // $id is replaced with the project ID.
-StudioView.PROJECT_PAGE = 'https://penguinmod.com/#$id';
+StudioView.PROJECT_PAGE = 'https://studio.penguinmod.com/#$id';
 
 // The amount of "placeholders" to insert before the next page loads.
 StudioView.PLACEHOLDER_COUNT = 9;

--- a/src/components/tw-studioview/studioview.js
+++ b/src/components/tw-studioview/studioview.js
@@ -307,7 +307,7 @@ StudioView.THUMBNAIL_SRC = 'https://projects.penguinmod.com/api/v1/projects/getp
 
 // The URL for project pages.
 // $id is replaced with the project ID.
-StudioView.PROJECT_PAGE = 'https://jwklong.github.io/penguinmod.github.io/#$id';
+StudioView.PROJECT_PAGE = 'https://penguinmod.com/#$id';
 
 // The amount of "placeholders" to insert before the next page loads.
 StudioView.PLACEHOLDER_COUNT = 9;

--- a/src/playground/credits/users.js
+++ b/src/playground/credits/users.js
@@ -21,7 +21,7 @@ const fromHardcodedGithub = username => ({
 });
 const fromHardcodedNamed = username => ({
     image: `https://penguinmod.com/unknown_user.png`,
-    href: "https://jwklong.github.io/penguinmod.github.io/credits.html#",
+    href: "https://penguinmod.com/credits.html#",
     text: username
 });
 

--- a/src/playground/credits/users.js
+++ b/src/playground/credits/users.js
@@ -21,7 +21,7 @@ const fromHardcodedGithub = username => ({
 });
 const fromHardcodedNamed = username => ({
     image: `https://penguinmod.com/unknown_user.png`,
-    href: "https://penguinmod.com/credits.html#",
+    href: "https://studio.penguinmod.com/credits.html#",
     text: username
 });
 

--- a/src/playground/render-interface.jsx
+++ b/src/playground/render-interface.jsx
@@ -164,7 +164,7 @@ const Footer = () => (
                     </a>
                 </div>
                 <div className={styles.footerSection}>
-                    <a href="https://penguinmod.com/PenguinMod-Packager">
+                    <a href="https://studio.penguinmod.com/PenguinMod-Packager">
                         {/* Do not translate */}
                         {'PenguinMod Packager'}
                     </a>

--- a/src/playground/render-interface.jsx
+++ b/src/playground/render-interface.jsx
@@ -164,7 +164,7 @@ const Footer = () => (
                     </a>
                 </div>
                 <div className={styles.footerSection}>
-                    <a href="https://jwklong.github.io/penguinmod.github.io/PenguinMod-Packager">
+                    <a href="https://penguinmod.com/PenguinMod-Packager">
                         {/* Do not translate */}
                         {'PenguinMod Packager'}
                     </a>


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #erm idk

### Proposed Changes

removes some uses of  jwklong.github.io, like on the project viewer thingy at the bottom of a project page

### Reason for Changes

server is not dead now so we should use penguinmod.com

### Test Coverage

erm i didnt

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

(theres no linux firefox and linux chrome)