### PR TITLE
Add next costume and previous costume to looks costume menu

### DIFF
--- a/src/lib/blocks.js
+++ b/src/lib/blocks.js
@@ -115,8 +115,22 @@ export default function (vm) {
     };
 
     const costumesMenu = function () {
+        const next = ScratchBlocks.ScratchMsgs.translate('LOOKS_NEXTCOSTUME', 'next costume');
+        const previous = "previous costume" //ScratchBlocks.ScratchMsgs.translate('LOOKS_PREVIOUSCOSTUME', 'previous costume');
+        // TODO: Add translation index into ScratchBlocks for this.
+
+        //const random = "random costume"//ScratchBlocks.ScratchMsgs.translate('LOOKS_RANDOMBACKDROP', 'random costume');
+        // TODO: Add this to VM: /src/blocks/scratch3_looks.js _setCostume function
+        // TODO: Add translation entry
         if (vm.editingTarget && vm.editingTarget.getCostumes().length > 0) {
-            return vm.editingTarget.getCostumes().map(costume => [costume.name, costume.name]);
+            return vm.editingTarget.getCostumes().map(costume => [costume.name, costume.name])
+                .concat([
+                    [next, "next costume"],
+                    [previous, "previous costume"],
+                    //[random, "random costume"]
+                    // TODO: Add this to VM: /src/blocks/scratch3_looks.js _setCostume function
+                ])
+            ;
         }
         return [['', '']];
     };


### PR DESCRIPTION
Adds the "next costume" and "previous costume" dropdown elements to the costume dropdown.

![image](https://github.com/user-attachments/assets/4e502929-6f3c-4dd7-821b-7c89b8fd4526)

[Discord suggestion](https://discord.com/channels/1033551490331197462/1324144281056972981)

## Known bugs
There's the bug that this is shown in the () of () block, but that seems a bit like an issue with that block, rather than an issue with this patch. I say this because it also occurs with the backdrop menu on the same block. In any case, that block should likely implement the next and previous for backdrops and costumes, anyway.

![image](https://github.com/user-attachments/assets/2ca30620-939d-40e2-9a8b-076a9bff7df9)
![image](https://github.com/user-attachments/assets/773fecb7-6d0b-4b8e-9f4a-af4f3a27c2c7)

FYI, this is now fixed in https://github.com/PenguinMod/PenguinMod-Vm/pull/105
