### PR TITLE
A little quaily of life change.

### DIFF
--- a/src/lib/tw-filesystem-api.js
+++ b/src/lib/tw-filesystem-api.js
@@ -18,6 +18,12 @@ const showOpenFilePicker = async () => {
         multiple: false,
         types: [
             {
+                description: 'Supported Files',
+                accept: {
+                    'application/x.scratch.sb3': ['.pmp', '.pm','.sb3', '.sb2', '.sb']
+                }
+            },
+            {
                 description: 'PenguinMod Project',
                 accept: {
                     'application/x.scratch.sb3': ['.pmp', '.pm']


### PR DESCRIPTION
This just adds a new file type thing to the drop down when opening a project. It automaticly shows you all, sb3, sb2, sb, pmp and pm when you open it. So you dont have to change it when you want to open a sb3 or something.