### PR TITLE
Animations

### DIFF
--- a/src/addons/addons.js
+++ b/src/addons/addons.js
@@ -77,6 +77,7 @@ const addons = [
 ];
 
 const newAddons = [
+    "animations",
     "paint-gradient-maker",
     "toolbox-full-blocks-on-hover",
     "waveform-chunk-size",

--- a/src/addons/addons/animations/_manifest_entry.js
+++ b/src/addons/addons/animations/_manifest_entry.js
@@ -25,10 +25,6 @@ const manifest = {
       "type": "select",
       "potentialValues": [
         {
-          "id": "none",
-          "name": "No animations"
-        },
-        {
           "id": "default",
           "name": "Moderate animations"
         },

--- a/src/addons/addons/animations/_manifest_entry.js
+++ b/src/addons/addons/animations/_manifest_entry.js
@@ -1,0 +1,47 @@
+const manifest = {
+  "name": "Animation Types",
+  "description": "Change the intensity of animations that appear in the editor. Some moderate animations come with the editor by default.",
+  "credits": [
+    {
+      "name": "Reflow"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js"
+    }
+  ],
+  "info": [
+    {
+      "text": "If you enabled a reduced motion setting on your device, these settings will not apply.",
+      "id": "reduced-motion"
+    }
+  ],
+  "settings": [
+     {
+      "dynamic": true,
+      "name": "Intensity",
+      "id": "intensity",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "none",
+          "name": "No animations"
+        },
+        {
+          "id": "default",
+          "name": "Moderate animations"
+        },
+        {
+          "id": "intense",
+          "name": "Shower me in animations"
+        }
+      ],
+      "default": "default"
+    }
+  ],
+  "tags": ["editor", "new"],
+  "enabledByDefault": true,
+  "dynamicDisable": true
+};
+export default manifest;

--- a/src/addons/addons/animations/_runtime_entry.js
+++ b/src/addons/addons/animations/_runtime_entry.js
@@ -1,0 +1,4 @@
+import _js from "./userscript.js";
+export const resources = {
+  "userscript.js": _js,
+};

--- a/src/addons/addons/animations/userscript.js
+++ b/src/addons/addons/animations/userscript.js
@@ -1,0 +1,18 @@
+export default async function ({ addon, console, msg }) {
+  function applySettings() {
+    ReduxStore.dispatch({
+      type: 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF',
+      animPref: addon.settings.get('intensity') || "default"
+    });
+  }
+  function resetSettings() {
+    ReduxStore.dispatch({
+      type: 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF',
+      animPref: "default"
+    });
+  }
+  addon.self.addEventListener("reenabled", applySettings);
+  addon.self.addEventListener("disabled", resetSettings);
+  addon.settings.addEventListener("change", applySettings);
+  applySettings();
+}

--- a/src/addons/addons/animations/userscript.js
+++ b/src/addons/addons/animations/userscript.js
@@ -2,13 +2,13 @@ export default async function ({ addon, console, msg }) {
   function applySettings() {
     ReduxStore.dispatch({
       type: 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF',
-      animPref: addon.settings.get('intensity') || "default"
+      animPref: addon.settings.get('intensity') || "none"
     });
   }
   function resetSettings() {
     ReduxStore.dispatch({
       type: 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF',
-      animPref: "default"
+      animPref: "none"
     });
   }
   addon.self.addEventListener("reenabled", applySettings);

--- a/src/addons/generated/addon-entries.js
+++ b/src/addons/generated/addon-entries.js
@@ -73,4 +73,5 @@ export default {
   "tw-disable-cloud-variables": () => import(/* webpackChunkName: "addon-entry-tw-disable-cloud-variables" */ "../addons/tw-disable-cloud-variables/_runtime_entry.js"),
   "vol-slider": () => import(/* webpackChunkName: "addon-entry-vol-slider" */ "../addons/vol-slider/_runtime_entry.js"),
   "waveform-chunk-size": () => import(/* webpackChunkName: "addon-default-entry" */ "../addons/waveform-chunk-size/_runtime_entry.js"),
+  "animations": () => import(/* webpackChunkName: "addon-entry-animations" */ "../addons/animations/_runtime_entry.js"),
 };

--- a/src/addons/generated/addon-manifests.js
+++ b/src/addons/generated/addon-manifests.js
@@ -71,8 +71,10 @@ import _tw_straighten_comments from "../addons/tw-straighten-comments/_manifest_
 import _tw_remove_feedback from "../addons/tw-remove-feedback/_manifest_entry.js";
 import _tw_remove_backpack from "../addons/tw-remove-backpack/_manifest_entry.js";
 import _tw_disable_cloud_variables from "../addons/tw-disable-cloud-variables/_manifest_entry.js";
+import _animations from "../addons/animations/_manifest_entry.js";
 
 export default {
+  "animations": _animations,
   "cat-blocks": _cat_blocks,
   "editor-devtools": _editor_devtools,
   "find-bar": _find_bar,

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -12,6 +12,10 @@
     user-select: none;
 }
 
+.no-animation {
+    transition: transform 0s ease !important;
+}
+
 .button {
     transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -12,6 +12,18 @@
     user-select: none;
 }
 
+.button {
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
+}
+
+.button:hover {
+    transform: scale(1.02);
+}
+
+.button:active {
+    transform: scale(0.95);
+}
+
 .icon {
     height: 1.5rem;
 }

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -34,6 +34,7 @@ const ButtonComponent = ({
         <span
             className={classNames(
                 styles.outlinedButton,
+                styles.button,
                 className
             )}
             role="button"

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -13,16 +14,19 @@ const ButtonComponent = ({
     iconHeight,
     onClick,
     children,
+    animPref,
     ...props
 }) => {
-
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (disabled) {
         onClick = function () {};
     }
 
     const icon = iconSrc && (
         <img
-            className={classNames(iconClassName, styles.icon)}
+            className={classNames(iconClassName, styles.icon, {
+                [styles.noAnimation]: animPref == 'none' || prefersReducedMotion
+            })}
             draggable={false}
             src={iconSrc}
             height={iconHeight}
@@ -58,4 +62,12 @@ ButtonComponent.propTypes = {
     onClick: PropTypes.func
 };
 
-export default ButtonComponent;
+const mapStateToProps = (state) => {
+    return {
+        animPref: state.scratchGui.addonUtil.editorAnimPref,
+    };
+};
+
+export default connect(
+    mapStateToProps
+)(ButtonComponent);

--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -21,7 +21,17 @@
     border-radius: $space;
     text-align: center;
     cursor: pointer;
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), border-color 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
+
+.library-item:hover {
+    transform: scale(1.02);
+}
+
+.library-item:active {
+    transform: scale(0.98);
+}
+
 [theme="dark"] .library-item {
     background: $ui-primary;
 }

--- a/src/components/library-item/library-item.css
+++ b/src/components/library-item/library-item.css
@@ -24,6 +24,10 @@
     transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), border-color 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
+.no-animation {
+    transition: transform 0s ease, border-color 0s ease !important;
+}
+
 .library-item:hover {
     transform: scale(1.02);
 }

--- a/src/components/library-item/library-item.jsx
+++ b/src/components/library-item/library-item.jsx
@@ -1,5 +1,6 @@
 import {FormattedMessage, intlShape, defineMessages} from 'react-intl';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import React from 'react';
 
 import Box from '../box/box.jsx';
@@ -32,13 +33,15 @@ const getMSFormatted = (ms) => {
 /* eslint-disable react/prefer-stateless-function */
 class LibraryItemComponent extends React.PureComponent {
     render() {
+        const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
         return this.props.featured ? (
             <div
                 className={classNames(
                     styles.libraryItem,
                     styles.featuredItem,
                     {
-                        [styles.disabled]: this.props.disabled
+                        [styles.disabled]: this.props.disabled,
+                        [styles.noAnimation]: this.props.animPref == 'none' || prefersReducedMotion,
                     },
                     typeof this.props.extensionId === 'string' ? styles.libraryItemExtension : null,
                     this.props.hidden ? styles.hidden : null
@@ -483,4 +486,12 @@ LibraryItemComponent.defaultProps = {
     showPlayButton: false
 };
 
-export default LibraryItemComponent;
+const mapStateToProps = (state) => {
+    return {
+        animPref: state.scratchGui.addonUtil.editorAnimPref,
+    };
+};
+
+export default connect(
+    mapStateToProps
+)(LibraryItemComponent);

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -306,6 +306,7 @@ class LibraryComponent extends React.Component {
                 contentLabel={this.props.title}
                 id={this.props.id}
                 onRequestClose={this.handleClose}
+                kind={this.props.kind}
             >
                 {/*
                     todo: translation support?

--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -19,6 +19,10 @@
     transition: opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
+.no-animation {
+    transition: opacity 0s ease, transform 0s ease !important;
+}
+
 .menu-visible {
     opacity: 1;
     transform: scale(1);

--- a/src/components/menu/menu.css
+++ b/src/components/menu/menu.css
@@ -13,7 +13,17 @@
     overflow: visible;
     color: $ui-white;
     box-shadow: 0 8px 8px 0 $ui-black-transparent-default;
+    transform-origin: top left;
+    opacity: 0;
+    transform: scale(0.6);
+    transition: opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
+
+.menu-visible {
+    opacity: 1;
+    transform: scale(1);
+}
+
 [theme="dark"] .menu {
     background-color: $motion-primary-dark;
 }

--- a/src/components/menu/menu.jsx
+++ b/src/components/menu/menu.jsx
@@ -1,16 +1,20 @@
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, {useState, useEffect, useRef} from 'react';
 import styles from './menu.css';
 
-const animIn = 0; // ms, you could add a delay but it doesn't feel right
+
 
 const MenuComponent = ({
     className = '',
     children,
     componentRef,
+    animPref,
     place = 'right'
-}) => {
+}, props) => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const animIn = animPref == "none" ? 0 : 0; // ms, you could add a delay but it doesn't feel right
     const [visible, setVisible] = useState(false); // provides a clear way to check visibility
     const waitOut = useRef(null);
 
@@ -30,6 +34,7 @@ const MenuComponent = ({
                     [styles.left]: place === 'left',
                     [styles.right]: place === 'right',
                     [styles.menuVisible]: visible,
+                    [styles.noAnimation]: animPref == 'none' || prefersReducedMotion
                 }
             )}
             ref={componentRef}
@@ -91,8 +96,14 @@ MenuSection.propTypes = {
     children: PropTypes.node
 };
 
-export {
-    MenuComponent as default,
-    MenuItem,
-    MenuSection
+export { MenuItem, MenuSection }; 
+
+const mapStateToProps = (state) => {
+    return {
+        animPref: state.scratchGui.addonUtil.editorAnimPref,
+    };
 };
+
+export default connect(
+    mapStateToProps
+)(MenuComponent);

--- a/src/components/menu/menu.jsx
+++ b/src/components/menu/menu.jsx
@@ -1,29 +1,43 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
-
+import React, {useState, useEffect, useRef} from 'react';
 import styles from './menu.css';
+
+const animIn = 0; // ms, you could add a delay but it doesn't feel right
 
 const MenuComponent = ({
     className = '',
     children,
     componentRef,
     place = 'right'
-}) => (
-    <ul
-        className={classNames(
-            styles.menu,
-            className,
-            {
-                [styles.left]: place === 'left',
-                [styles.right]: place === 'right'
-            }
-        )}
-        ref={componentRef}
-    >
-        {children}
-    </ul>
-);
+}) => {
+    const [visible, setVisible] = useState(false); // provides a clear way to check visibility
+    const waitOut = useRef(null);
+
+    useEffect(() => {
+        const waitIn = setTimeout(() => setVisible(true), animIn); 
+        return () => {
+            clearTimeout(waitIn);
+            if (waitOut.current) clearTimeout(waitOut.current);
+        };
+    }, []);
+    return (
+        <ul
+            className={classNames(
+                styles.menu,
+                className,
+                {
+                    [styles.left]: place === 'left',
+                    [styles.right]: place === 'right',
+                    [styles.menuVisible]: visible,
+                }
+            )}
+            ref={componentRef}
+        >
+            {children}
+        </ul>
+    )
+};
 
 MenuComponent.propTypes = {
     children: PropTypes.node,

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -10,13 +10,53 @@
     bottom: 0;
     z-index: $z-index-modal;
     background-color: $ui-modal-overlay;
+    opacity: 0;
+    transition: opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
+
+.modal-overlay-visible {
+    opacity: 1;
+}
+
 .scrollable {
     overflow: auto;
 }
 
 .modal-content * {
     box-sizing: border-box;
+}
+
+.full-screen {
+    opacity: 0;
+    transform: scale(0);
+    transition: opacity 0.5s cubic-bezier(0.63, 0.32, 0.08, 0.95), transform 0.5s cubic-bezier(0.63, 0.32, 0.08, 0.95);
+    -webkit-perspective: 240px;
+    perspective: 240px;
+}
+
+.modal-container {
+    opacity: 0;
+    transform: scale(0.7) rotateX(-45deg);
+    transition: opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), transform 0.2s cubic-bezier(0.63, 0.32, 0.08, 0.95);
+    -webkit-perspective: 240px;
+    perspective: 240px;
+    max-width: max(60%, 750px);
+    width: max(60%, 750px);
+}
+
+
+.modal-fs-visible {
+    opacity: 1;
+    transform: scale(1) rotateX(0deg);
+}
+
+.modal-visible {
+    opacity: 1;
+    transform: scale(1) rotateX(0deg);
+}
+
+.ext-modal {
+    transform-origin: bottom left;
 }
 
 .modal-content {

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -45,6 +45,10 @@
 }
 
 
+.no-animation {
+    transition: opacity 0s ease, transform 0s ease !important;
+}
+
 .modal-fs-visible {
     opacity: 1;
     transform: scale(1) rotateX(0deg);

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, {useState, useEffect, useRef, useCallback} from 'react';
 import ReactModal from 'react-modal';
@@ -13,9 +14,11 @@ import helpIcon from '../../lib/assets/icon--help.svg';
 
 import styles from './modal.css';
 
-const animOut = 200; // ms
+
 
 const ModalComponent = props => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const animOut = props.animPref == "none" ? 0 : 200; // ms
     const [visible, setVisible] = useState(false); // provides a clear way to check visibility
     const waitOut = useRef(null);
     const onReqCloseRef = useRef(props.onRequestClose);
@@ -50,13 +53,15 @@ const ModalComponent = props => {
                     [styles.fullScreen]: props.fullScreen,
                     [styles.modalFsVisible]: visible && props.fullScreen,
                     [styles.modalVisible]: visible && !props.fullScreen,
-                    [styles.extModal]: props.kind == 'extension'
+                    [styles.extModal]: props.kind == 'extension',
+                    [styles.noAnimation]: (props.animPref != 'intense' && props.fullScreen) || props.animPref == 'none' || prefersReducedMotion
                 }
             )}
             contentLabel={props.contentLabel}
             overlayClassName={classNames(styles.modalOverlay, {
                 [styles.scrollable]: props.scrollable,
                 [styles.modalOverlayVisible]: visible,
+                [styles.noAnimation]: (props.animPref != 'intense' && props.fullScreen) || props.animPref == 'none' || prefersReducedMotion
             })}
         >
             <Box
@@ -144,7 +149,16 @@ ModalComponent.propTypes = {
     isRtl: PropTypes.bool,
     onHelp: PropTypes.func,
     onRequestClose: PropTypes.func,
-    scrollable: PropTypes.bool
+    scrollable: PropTypes.bool,
+    animPref: PropTypes.string 
 };
 
-export default ModalComponent;
+const mapStateToProps = (state) => {
+    return {
+        animPref: state.scratchGui.addonUtil.editorAnimPref,
+    };
+};
+
+export default connect(
+    mapStateToProps
+)(ModalComponent);

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 import ReactModal from 'react-modal';
 import {FormattedMessage} from 'react-intl';
 
@@ -13,88 +13,123 @@ import helpIcon from '../../lib/assets/icon--help.svg';
 
 import styles from './modal.css';
 
-const ModalComponent = props => (
-    <ReactModal
-        isOpen
-        className={classNames(styles.modalContent, props.className, {
-            [styles.fullScreen]: props.fullScreen
-        })}
-        contentLabel={props.contentLabel}
-        overlayClassName={classNames(styles.modalOverlay, {
-            [styles.scrollable]: props.scrollable
-        })}
-        onRequestClose={props.onRequestClose}
-    >
-        <Box
-            dir={props.isRtl ? 'rtl' : 'ltr'}
-            direction="column"
-            grow={1}
+const animOut = 200; // ms
+
+const ModalComponent = props => {
+    const [visible, setVisible] = useState(false); // provides a clear way to check visibility
+    const waitOut = useRef(null);
+    const onReqCloseRef = useRef(props.onRequestClose);
+
+    useEffect(() => {
+        onReqCloseRef.current = props.onRequestClose;
+    }, [props.onRequestClose]);
+
+    useEffect(() => {
+        const waitIn = setTimeout(() => setVisible(true), 0); // you could add an "in" delay here but it just doesn't feel right
+        return () => {
+            clearTimeout(waitIn);
+            if (waitOut.current) clearTimeout(waitOut.current);
+        };
+    }, []);
+
+    const closeThisModal = useCallback(() => {
+        setVisible(false); // animate out
+        waitOut.current = setTimeout(() => {
+            if (onReqCloseRef.current) onReqCloseRef.current(); // close window after animating out 
+        }, animOut);
+    }, []);
+
+    return (
+         <ReactModal
+            isOpen
+            className={classNames(
+                styles.modalContent,
+                props.className,
+                {
+                    [styles.modalContainer]: !props.fullScreen,
+                    [styles.fullScreen]: props.fullScreen,
+                    [styles.modalFsVisible]: visible && props.fullScreen,
+                    [styles.modalVisible]: visible && !props.fullScreen,
+                    [styles.extModal]: props.kind == 'extension'
+                }
+            )}
+            contentLabel={props.contentLabel}
+            overlayClassName={classNames(styles.modalOverlay, {
+                [styles.scrollable]: props.scrollable,
+                [styles.modalOverlayVisible]: visible,
+            })}
         >
-            <div className={classNames(styles.header, props.headerClassName)}>
-                {props.onHelp ? (
+            <Box
+                dir={props.isRtl ? 'rtl' : 'ltr'}
+                direction="column"
+                grow={1}
+            >
+                <div className={classNames(styles.header, props.headerClassName)}>
+                    {props.onHelp ? (
+                        <div
+                            className={classNames(
+                                styles.headerItem,
+                                styles.headerItemHelp
+                            )}
+                        >
+                            <Button
+                                className={styles.helpButton}
+                                iconSrc={helpIcon}
+                                onClick={props.onHelp}
+                            >
+                                <FormattedMessage
+                                    defaultMessage="Help"
+                                    description="Help button in modal"
+                                    id="gui.modal.help"
+                                />
+                            </Button>
+                        </div>
+                    ) : null}
                     <div
                         className={classNames(
                             styles.headerItem,
-                            styles.headerItemHelp
+                            styles.headerItemTitle
                         )}
                     >
-                        <Button
-                            className={styles.helpButton}
-                            iconSrc={helpIcon}
-                            onClick={props.onHelp}
-                        >
-                            <FormattedMessage
-                                defaultMessage="Help"
-                                description="Help button in modal"
-                                id="gui.modal.help"
+                        {props.headerImage ? (
+                            <img
+                                className={styles.headerImage}
+                                src={props.headerImage}
                             />
-                        </Button>
+                        ) : null}
+                        {props.contentLabel}
                     </div>
-                ) : null}
-                <div
-                    className={classNames(
-                        styles.headerItem,
-                        styles.headerItemTitle
-                    )}
-                >
-                    {props.headerImage ? (
-                        <img
-                            className={styles.headerImage}
-                            src={props.headerImage}
-                        />
-                    ) : null}
-                    {props.contentLabel}
-                </div>
-                <div
-                    className={classNames(
-                        styles.headerItem,
-                        styles.headerItemClose
-                    )}
-                >
-                    {props.fullScreen ? (
-                        <Button
-                            className={styles.backButton}
-                            iconSrc={backIcon}
-                            onClick={props.onRequestClose}
-                        >
-                            <FormattedMessage
-                                defaultMessage="Back"
-                                description="Back button in modal"
-                                id="gui.modal.back"
+                    <div
+                        className={classNames(
+                            styles.headerItem,
+                            styles.headerItemClose
+                        )}
+                    >
+                        {props.fullScreen ? (
+                            <Button
+                                className={styles.backButton}
+                                iconSrc={backIcon}
+                                onClick={closeThisModal}
+                            >
+                                <FormattedMessage
+                                    defaultMessage="Back"
+                                    description="Back button in modal"
+                                    id="gui.modal.back"
+                                />
+                            </Button>
+                        ) : (
+                            <CloseButton
+                                size={CloseButton.SIZE_LARGE}
+                                onClick={closeThisModal}
                             />
-                        </Button>
-                    ) : (
-                        <CloseButton
-                            size={CloseButton.SIZE_LARGE}
-                            onClick={props.onRequestClose}
-                        />
-                    )}
+                        )}
+                    </div>
                 </div>
-            </div>
-            {props.children}
-        </Box>
-    </ReactModal>
-);
+                {props.children}
+            </Box>
+        </ReactModal>
+    )
+};
 
 ModalComponent.propTypes = {
     children: PropTypes.node,

--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -20,6 +20,12 @@
     cursor: pointer;
 
     user-select: none;
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
+}
+
+.deleting {
+    opacity: 0;
+    transform: scale(0);
 }
 
 .sprite-selector-item.is-selected {

--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -23,6 +23,10 @@
     transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
+.no-animation {
+    transition: opacity 0s ease, transform 0s ease !important;
+}
+
 .deleting {
     opacity: 0;
     transform: scale(0);

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import React, {useState, useEffect, useRef, useCallback} from 'react';
 
 import DeleteButton from '../delete-button/delete-button.jsx';
@@ -11,9 +12,11 @@ import { FormattedMessage } from 'react-intl';
 // react-contextmenu requires unique id to match trigger and context menu
 let contextMenuId = 0;
 
-const animOut = 150; // ms
+
 
 const SpriteSelectorItem = props => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const animOut = props.animPref == "none" ? 0 : 150; // ms
     const [visible, setVisible] = useState(true); // provides a clear way to check visibility
     const waitOut = useRef(null);
     const onReqCloseRef = useRef(props.onDeleteButtonClick);
@@ -43,7 +46,8 @@ const SpriteSelectorItem = props => {
             attributes={{
                 className: classNames(props.className, styles.spriteSelectorItem, {
                     [styles.isSelected]: props.selected,
-                    [styles.deleting]: !visible
+                    [styles.deleting]: !visible,
+                    [styles.noAnimation]: props.animPref == 'none' || prefersReducedMotion
                 }),
                 onClick: props.onClick,
                 onMouseEnter: props.onMouseEnter,
@@ -145,4 +149,12 @@ SpriteSelectorItem.propTypes = {
     selected: PropTypes.bool.isRequired
 };
 
-export default SpriteSelectorItem;
+const mapStateToProps = (state) => {
+    return {
+        animPref: state.scratchGui.addonUtil.editorAnimPref,
+    };
+};
+
+export default connect(
+    mapStateToProps
+)(SpriteSelectorItem);

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -1,100 +1,129 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 
 import DeleteButton from '../delete-button/delete-button.jsx';
 import styles from './sprite-selector-item.css';
-import {ContextMenuTrigger} from 'react-contextmenu';
-import {DangerousMenuItem, ContextMenu, MenuItem} from '../context-menu/context-menu.jsx';
-import {FormattedMessage} from 'react-intl';
+import { ContextMenuTrigger } from 'react-contextmenu';
+import { DangerousMenuItem, ContextMenu, MenuItem } from '../context-menu/context-menu.jsx';
+import { FormattedMessage } from 'react-intl';
 
 // react-contextmenu requires unique id to match trigger and context menu
 let contextMenuId = 0;
 
-const SpriteSelectorItem = props => (
-    <ContextMenuTrigger
-        attributes={{
-            className: classNames(props.className, styles.spriteSelectorItem, {
-                [styles.isSelected]: props.selected
-            }),
-            onClick: props.onClick,
-            onMouseEnter: props.onMouseEnter,
-            onMouseLeave: props.onMouseLeave,
-            onMouseDown: props.onMouseDown,
-            onTouchStart: props.onMouseDown
-        }}
-        disable={props.preventContextMenu}
-        id={`${props.name}-${contextMenuId}`}
-        ref={props.componentRef}
-    >
-        {typeof props.number === 'undefined' ? null : (
-            <div className={styles.number}>{props.number}</div>
-        )}
-        {props.costumeURL ? (
-            <div className={styles.spriteImageOuter}>
-                <div className={styles.spriteImageInner}>
-                    <img
-                        className={styles.spriteImage}
-                        draggable={false}
-                        src={props.costumeURL}
-                    />
+const animOut = 150; // ms
+
+const SpriteSelectorItem = props => {
+    const [visible, setVisible] = useState(true); // provides a clear way to check visibility
+    const waitOut = useRef(null);
+    const onReqCloseRef = useRef(props.onDeleteButtonClick);
+
+    useEffect(() => {
+        onReqCloseRef.current = props.onDeleteButtonClick;
+    }, [props.onDeleteButtonClick]);
+
+    useEffect(() => {
+        const waitIn = setTimeout(() => setVisible(true), 0); // you could add an "in" delay here but it just doesn't feel right
+        return () => {
+            clearTimeout(waitIn);
+            if (waitOut.current) clearTimeout(waitOut.current);
+        };
+    }, []);
+
+    const onDelete = useCallback(() => {
+        setVisible(false); // animate out
+        waitOut.current = setTimeout(() => {
+            console.log('SpriteSelectorItem: onDelete');
+            if (onReqCloseRef.current) onReqCloseRef.current(); // delete sprite after animating out 
+        }, animOut);
+    }, []);
+
+    return (
+        <ContextMenuTrigger
+            attributes={{
+                className: classNames(props.className, styles.spriteSelectorItem, {
+                    [styles.isSelected]: props.selected,
+                    [styles.deleting]: !visible
+                }),
+                onClick: props.onClick,
+                onMouseEnter: props.onMouseEnter,
+                onMouseLeave: props.onMouseLeave,
+                onMouseDown: props.onMouseDown,
+                onTouchStart: props.onMouseDown
+            }}
+            disable={props.preventContextMenu}
+            id={`${props.name}-${contextMenuId}`}
+            ref={props.componentRef}
+        >
+            {typeof props.number === 'undefined' ? null : (
+                <div className={styles.number}>{props.number}</div>
+            )}
+            {props.costumeURL ? (
+                <div className={styles.spriteImageOuter}>
+                    <div className={styles.spriteImageInner}>
+                        <img
+                            className={styles.spriteImage}
+                            draggable={false}
+                            src={props.costumeURL}
+                        />
+                    </div>
                 </div>
-            </div>
-        ) : null}
-        <div className={styles.spriteInfo}>
-            <div className={styles.spriteName}>{props.name}</div>
-            {props.details ? (
-                <div className={styles.spriteDetails}>{props.details}</div>
             ) : null}
-        </div>
-        {(props.selected && props.onDeleteButtonClick) ? (
-            <DeleteButton
-                className={styles.deleteButton}
-                onClick={props.onDeleteButtonClick}
-            />
-        ) : null }
-        {props.onDuplicateButtonClick || props.onDeleteButtonClick || props.onExportButtonClick ? (
-            <ContextMenu id={`${props.name}-${contextMenuId++}`}>
-                {props.onDuplicateButtonClick ? (
-                    <MenuItem onClick={props.onDuplicateButtonClick}>
-                        <FormattedMessage
-                            defaultMessage="duplicate"
-                            description="Menu item to duplicate in the right click menu"
-                            id="gui.spriteSelectorItem.contextMenuDuplicate"
-                        />
-                    </MenuItem>
+            <div className={styles.spriteInfo}>
+                <div className={styles.spriteName}>{props.name}</div>
+                {props.details ? (
+                    <div className={styles.spriteDetails}>{props.details}</div>
                 ) : null}
-                {props.onExportButtonClick ? (
-                    <MenuItem onClick={props.onExportButtonClick}>
-                        <FormattedMessage
-                            defaultMessage="export"
-                            description="Menu item to export the selected item"
-                            id="gui.spriteSelectorItem.contextMenuExport"
-                        />
-                    </MenuItem>
-                ) : null }
-                {props.onRenameButtonClick ? (
-                    <MenuItem onClick={props.onRenameButtonClick}>
-                        <FormattedMessage
-                            defaultMessage="rename"
-                            description="Menu item to rename an item"
-                            id="tw.spriteSelectorItem.rename"
-                        />
-                    </MenuItem>
-                ) : null}
-                {props.onDeleteButtonClick ? (
-                    <DangerousMenuItem onClick={props.onDeleteButtonClick}>
-                        <FormattedMessage
-                            defaultMessage="delete"
-                            description="Menu item to delete in the right click menu"
-                            id="gui.spriteSelectorItem.contextMenuDelete"
-                        />
-                    </DangerousMenuItem>
-                ) : null }
-            </ContextMenu>
-        ) : null}
-    </ContextMenuTrigger>
-);
+            </div>
+            {(props.selected && props.onDeleteButtonClick) ? (
+                <DeleteButton
+                    className={styles.deleteButton}
+                    onClick={onDelete}
+                />
+            ) : null}
+            {props.onDuplicateButtonClick || props.onDeleteButtonClick || props.onExportButtonClick ? (
+                <ContextMenu id={`${props.name}-${contextMenuId++}`}>
+                    {props.onDuplicateButtonClick ? (
+                        <MenuItem onClick={props.onDuplicateButtonClick}>
+                            <FormattedMessage
+                                defaultMessage="duplicate"
+                                description="Menu item to duplicate in the right click menu"
+                                id="gui.spriteSelectorItem.contextMenuDuplicate"
+                            />
+                        </MenuItem>
+                    ) : null}
+                    {props.onExportButtonClick ? (
+                        <MenuItem onClick={props.onExportButtonClick}>
+                            <FormattedMessage
+                                defaultMessage="export"
+                                description="Menu item to export the selected item"
+                                id="gui.spriteSelectorItem.contextMenuExport"
+                            />
+                        </MenuItem>
+                    ) : null}
+                    {props.onRenameButtonClick ? (
+                        <MenuItem onClick={props.onRenameButtonClick}>
+                            <FormattedMessage
+                                defaultMessage="rename"
+                                description="Menu item to rename an item"
+                                id="tw.spriteSelectorItem.rename"
+                            />
+                        </MenuItem>
+                    ) : null}
+                    {props.onDeleteButtonClick ? (
+                        <DangerousMenuItem onClick={props.onDeleteButtonClick}>
+                            <FormattedMessage
+                                defaultMessage="delete"
+                                description="Menu item to delete in the right click menu"
+                                id="gui.spriteSelectorItem.contextMenuDelete"
+                            />
+                        </DangerousMenuItem>
+                    ) : null}
+                </ContextMenu>
+            ) : null}
+        </ContextMenuTrigger>
+    );
+}
 
 SpriteSelectorItem.propTypes = {
     className: PropTypes.string,

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -214,6 +214,7 @@ class ExtensionLibrary extends React.PureComponent {
                 id="extensionLibrary"
                 actor="ExtensionLibrary"
                 header={"Extensions"}
+                kind="extension"
                 title={this.props.intl.formatMessage(messages.extensionTitle)}
                 visible={this.props.visible}
                 onItemSelected={this.handleItemSelect}

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -91,7 +91,7 @@ class SpriteSelectorItem extends React.PureComponent {
         }
     }
     handleDelete (e) {
-        e.stopPropagation(); // To prevent from bubbling back to handleClick
+        if (e) e.stopPropagation(); // To prevent from bubbling back to handleClick
         this.props.onDeleteButtonClick(this.props.id);
     }
     handleDuplicate (e) {

--- a/src/reducers/addon-util.js
+++ b/src/reducers/addon-util.js
@@ -1,7 +1,9 @@
 const SET_SOUND_EDITOR_WAVEFORM_CHUNK_SIZE = 'scratch-gui/addon-util/SET_SOUND_EDITOR_WAVEFORM_CHUNK_SIZE';
+const SET_EDITOR_ANIM_PREF = 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF';
 
 const initialState = {
     soundEditorWaveformChunkSize: 1024,
+    editorAnimPref: 'default'
 };
 
 const reducer = function (state, action) {
@@ -10,6 +12,10 @@ const reducer = function (state, action) {
         case SET_SOUND_EDITOR_WAVEFORM_CHUNK_SIZE:
             return {
                 soundEditorWaveformChunkSize: action.chunkSize
+            };
+        case SET_EDITOR_ANIM_PREF:
+            return {
+                editorAnimPref: action.animPref
             };
         default:
             return state;
@@ -23,8 +29,16 @@ const setSoundEditorWaveformChunkSize = function (chunkSize) {
     };
 };
 
+const setEditorAnimPref = function (preference) {
+    return {
+        type: SET_EDITOR_ANIM_PREF,
+        animPref: preference
+    };
+};
+
 export {
     reducer as default,
     initialState as addonUtilInitialState,
-    setSoundEditorWaveformChunkSize
+    setSoundEditorWaveformChunkSize,
+    setEditorAnimPref
 };


### PR DESCRIPTION
### Proposed Changes

_Describe what this Pull Request does_

### Adds a few animations to various things around the editor

_Explain why these changes should be made_

Because animations look really cool and make the editor feel more responsive (also because JWK told me to make a PR with my animations from a separate mod)

### Notes
This change adds the following animations:
- popout anims for all modals
- hover and press anims for some buttons (only those that use the <Button> component)
- hover and press anims for all library items
- popout anims for topbar menus
- deletion anims for all items that support deletion

It would be ideal to add support for CSS's `prefers-reduced-motion` media query or an option on the page to disable animations independent of OS settings but I have omitted it for simplicity.
