### PR TITLE
Update "Reactive" Addon

### DIFF
--- a/src/addons/addons/animations/_manifest_entry.js
+++ b/src/addons/addons/animations/_manifest_entry.js
@@ -1,6 +1,6 @@
 const manifest = {
-  "name": "Reactive",
-  "description": "Adds animations and reactiveness to parts of the editor. (formerly Animation Types)",
+  "name": "Reactive: Animations",
+  "description": "Adds animations to parts of the editor. Some parts of Reactive come with the editor and are not controlled here. These settings control animations and vigorous movement only. (formerly Animation Types)",
   "credits": [
     {
       "name": "Reflow"
@@ -11,16 +11,25 @@ const manifest = {
       "url": "userscript.js"
     }
   ],
+  "userstyles": [
+    {
+      "url": "style.css"
+    }
+  ],
   "info": [
     {
       "text": "If you enabled a reduced motion setting on your device, these settings will not apply. See how to re-enable motion: https://mgik.dev/turn-on-motion",
       "id": "reduced-motion"
+    },
+    {
+      "text": "Reactive is experimental. If anything stops working because of it (I'm sure there will be a few things), create an issue on the Github and mention me (@mmmmaaaaarrrrrrkkkkkkkk), and I will do my best to make a fix.",
+      "id": "experimental"
     }
   ],
   "settings": [
      {
       "dynamic": true,
-      "name": "Intensity",
+      "name": "Animation Intensity",
       "id": "intensity",
       "type": "select",
       "potentialValues": [
@@ -34,6 +43,23 @@ const manifest = {
         }
       ],
       "default": "default"
+    },
+    {
+      "dynamic": true,
+      "name": "Sprite/Costume/Sound Deletion Animation",
+      "id": "deleteAnim",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "shrink",
+          "name": "Shrink to nothing"
+        },
+        {
+          "id": "fly",
+          "name": "Fly out"
+        }
+      ],
+      "default": "shrink"
     }
   ],
   "tags": ["editor", "new"],

--- a/src/addons/addons/animations/_runtime_entry.js
+++ b/src/addons/addons/animations/_runtime_entry.js
@@ -1,4 +1,6 @@
 import _js from "./userscript.js";
+import _css from "!css-loader!./style.css";
 export const resources = {
   "userscript.js": _js,
+  "style.css": _css,
 };

--- a/src/addons/addons/animations/style.css
+++ b/src/addons/addons/animations/style.css
@@ -1,0 +1,11 @@
+.scratchCategoryMenuItem {
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
+}
+
+.scratchCategoryMenuItem:hover {
+    transform: scale(1.05);
+}
+
+.scratchCategoryMenuItem:active {
+    transform: scale(0.95);
+}

--- a/src/addons/addons/animations/userscript.js
+++ b/src/addons/addons/animations/userscript.js
@@ -1,14 +1,16 @@
 export default async function ({ addon, console, msg }) {
   function applySettings() {
     ReduxStore.dispatch({
-      type: 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF',
-      animPref: addon.settings.get('intensity') || "none"
+      type: 'scratch-gui/addon-util/SET_REACTIVE_SETTINGS',
+      animPref: addon.settings.get('intensity') || "none",
+      deleteAnim: addon.settings.get('deleteAnim') || "shrink",
     });
   }
   function resetSettings() {
     ReduxStore.dispatch({
-      type: 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF',
-      animPref: "none"
+      type: 'scratch-gui/addon-util/SET_REACTIVE_SETTINGS',
+      animPref: "none",
+      deleteAnim: "shrink",
     });
   }
   addon.self.addEventListener("reenabled", applySettings);

--- a/src/addons/modal.js
+++ b/src/addons/modal.js
@@ -5,10 +5,16 @@ import closeIcon from '../components/close-button/icon--close.svg';
 import styles from './modal.css';
 
 export const createEditorModal = (tab, title, {isOpen = false} = {}) => {
+     const shouldAnimate = !(window.ReduxStore &&
+        window.ReduxStore.getState &&
+        window.ReduxStore.getState().scratchGui &&
+        window.ReduxStore.getState().scratchGui.addonUtil &&
+        window.ReduxStore.getState().scratchGui.addonUtil.editorAnimPref === "none");
     const container = Object.assign(document.createElement('div'), {
         className: tab.scratchClass('modal_modal-overlay'),
         dir: tab.direction
     });
+    
     setTimeout(() => {
         container.classList.add(tab.scratchClass('modal_modal-overlay-visible'));
     });
@@ -24,6 +30,10 @@ export const createEditorModal = (tab, title, {isOpen = false} = {}) => {
     setTimeout(() => {
         modalOuter.classList.add(tab.scratchClass('modal_modal-visible'));
     });
+    if (!shouldAnimate) {
+        modalOuter.classList.add(tab.scratchClass('modal_no-animation'));
+        container.classList.add(tab.scratchClass('modal_no-animation'));
+    }
     modal.addEventListener('click', e => e.stopPropagation());
     container.appendChild(modalOuter);
     const header = Object.assign(document.createElement('div'), {
@@ -54,6 +64,8 @@ export const createEditorModal = (tab, title, {isOpen = false} = {}) => {
         className: styles.modalContent
     });
     modal.appendChild(content);
+   
+
     return {
         container: modalOuter,
         content,
@@ -63,9 +75,27 @@ export const createEditorModal = (tab, title, {isOpen = false} = {}) => {
             container.style.display = '';
         },
         close: () => {
-            container.style.display = 'none';
+            container.classList.remove(tab.scratchClass('modal_modal-overlay-visible'));
+            modalOuter.classList.remove(tab.scratchClass('modal_modal-visible'));
+            if (shouldAnimate) {
+                setTimeout(() => {
+                    container.style.display = 'none';
+                }, 150);
+            } else {
+                container.style.display = 'none';
+            }
         },
-        remove: container.remove.bind(container)
+        remove: () => {
+            container.classList.remove(tab.scratchClass('modal_modal-overlay-visible'));
+            modalOuter.classList.remove(tab.scratchClass('modal_modal-visible'));
+            if (shouldAnimate) {
+                setTimeout(() => {
+                    container.remove();
+                }, 150);
+            } else {
+                container.remove();
+            }
+        }
     };
 };
 

--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -94,6 +94,8 @@
     font-size: 0.65rem;
 }
 
+
+
 .blocks :global(.blocklyMinimalBody) {
     min-width: auto;
     min-height: auto;

--- a/src/components/context-menu/context-menu.css
+++ b/src/components/context-menu/context-menu.css
@@ -4,17 +4,18 @@
 
 .context-menu {
     min-width: 130px;
-    padding: 5px 0; /* The white strip at the top and bottom of the menu */
+    padding: 2px 0; 
     margin: 2px 0 0; /* To keep the menu below the cursor comfortably */
     font-size: 0.85rem;
     text-align: left;
     background-color: $ui-white;
     border: 1px solid $ui-black-transparent;
-    border-radius: calc($space / 2);
+    border-radius: calc($space / 1.1);
     box-shadow: 0px 0px 5px 1px $ui-black-transparent-default;
     pointer-events: none;
     transition: opacity 0.2s ease;
     z-index: $z-index-context-menu;
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), border-radius 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 [theme="dark"] .context-menu {
     background-color: $ui-primary;
@@ -27,10 +28,15 @@
     transition: 0.1s ease;
 }
 
+
 .menu-item:hover {
-    background: $motion-primary;
+    background: $ui-black-transparent;
     color: white;
+    transform: scale(0.95);
+    border-radius: 5px;
 }
+
+
 
 .menu-item-bordered {
     border-top: 1px solid $ui-black-transparent;

--- a/src/components/green-flag/green-flag.css
+++ b/src/components/green-flag/green-flag.css
@@ -8,12 +8,18 @@
     user-select: none;
     user-drag: none;
     cursor: pointer;
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
 .green-flag:hover {
     background-color: $motion-light-transparent;
+    transform: scale(1.05);
 }
 
 .green-flag.is-active {
     background-color: $motion-transparent;
+}
+
+.green-flag:active {
+    transform: scale(0.95);
 }

--- a/src/components/menu-bar/menu-bar.css
+++ b/src/components/menu-bar/menu-bar.css
@@ -77,14 +77,26 @@
     position: relative;
     align-items: center;
     white-space: nowrap;
-    height: $menu-bar-height;
+    height: calc($menu-bar-height - 10px);
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), background-color 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), border-radius 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
+
+.menu-bar-item.hoverable:hover {
+    transform: scale(1.1);
+    border-radius: 10px;
+}
+
+.menu-bar-item.active {
+    transform: scale(1) !important;
+    border-radius: 10px;
+}
+
+
 
 .menu-bar-item.hoverable {
     cursor: pointer;
 }
 
-.menu-bar-item.active,
 .menu-bar-item.hoverable:hover {
     background-color: $ui-black-transparent;
 }

--- a/src/components/pause-button/pause-button.css
+++ b/src/components/pause-button/pause-button.css
@@ -8,8 +8,14 @@
     user-select: none;
     user-drag: none;
     cursor: pointer;
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
 .pause-btn:hover {
     background-color: $motion-light-transparent;
+    transform: scale(1.05);
+}
+
+.pause-btn:active {
+    transform: scale(0.95);
 }

--- a/src/components/sprite-selector-item/sprite-selector-item.css
+++ b/src/components/sprite-selector-item/sprite-selector-item.css
@@ -23,13 +23,29 @@
     transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
+.sprite-selector-parent {
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95), opacity 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
+}
+
+.sprite-selector-parent:active .sprite-selector-item {
+    transform: scale(0.95);
+}
+.sprite-selector-parent:hover .sprite-selector-item {
+    transform: scale(1.05);
+}
+
 .no-animation {
     transition: opacity 0s ease, transform 0s ease !important;
 }
 
-.deleting {
+.deleting-shrink {
     opacity: 0;
     transform: scale(0);
+}
+
+.deleting-fly {
+    opacity: 0;
+    transform: scale(1.5) translateY(-100%) rotateX(-45deg);
 }
 
 .sprite-selector-item.is-selected {

--- a/src/components/sprite-selector-item/sprite-selector-item.jsx
+++ b/src/components/sprite-selector-item/sprite-selector-item.jsx
@@ -44,9 +44,10 @@ const SpriteSelectorItem = props => {
     return (
         <ContextMenuTrigger
             attributes={{
-                className: classNames(props.className, styles.spriteSelectorItem, {
+                className: classNames(props.className, styles.spriteSelectorParent, {
                     [styles.isSelected]: props.selected,
-                    [styles.deleting]: !visible,
+                    [styles.deletingFly]: !visible && (props.deleteAnim == "fly"),
+                    [styles.deletingShrink]: !visible && (props.deleteAnim == "shrink"),
                     [styles.noAnimation]: props.animPref == 'none' || prefersReducedMotion
                 }),
                 onClick: props.onClick,
@@ -58,7 +59,9 @@ const SpriteSelectorItem = props => {
             disable={props.preventContextMenu}
             id={`${props.name}-${contextMenuId}`}
             ref={props.componentRef}
-        >
+        >   <div className={classNames(props.className, styles.spriteSelectorItem, {
+            [styles.isSelected]: props.selected,
+        })}>
             {typeof props.number === 'undefined' ? null : (
                 <div className={styles.number}>{props.number}</div>
             )}
@@ -85,6 +88,7 @@ const SpriteSelectorItem = props => {
                     onClick={onDelete}
                 />
             ) : null}
+            </div>
             {props.onDuplicateButtonClick || props.onDeleteButtonClick || props.onExportButtonClick ? (
                 <ContextMenu id={`${props.name}-${contextMenuId++}`}>
                     {props.onDuplicateButtonClick ? (
@@ -152,6 +156,7 @@ SpriteSelectorItem.propTypes = {
 const mapStateToProps = (state) => {
     return {
         animPref: state.scratchGui.addonUtil.editorAnimPref,
+        deleteAnim: state.scratchGui.addonUtil.editorDeleteAnim,
     };
 };
 

--- a/src/components/stop-all/stop-all.css
+++ b/src/components/stop-all/stop-all.css
@@ -7,10 +7,12 @@
     border-radius: 0.25rem;
     user-select: none;
     cursor: pointer;
+    transition: transform 0.15s cubic-bezier(0.63, 0.32, 0.08, 0.95);
 }
 
 .stop-all:hover {
     background-color: $motion-light-transparent;
+    transform: scale(1.05);
 }
 
 .stop-all {
@@ -19,4 +21,8 @@
 
 .stop-all.is-active {
     opacity: 1;
+}
+
+.stop-all:active {
+    transform: scale(0.95);
 }

--- a/src/containers/sound-editor.jsx
+++ b/src/containers/sound-editor.jsx
@@ -661,12 +661,21 @@ class SoundEditor extends React.Component {
 
     // TODO: use actual scratch-gui menus instead of this
     displayPopup(title, width, height, okname, denyname, accepted, cancelled) {
+        const shouldAnimate = !(window.ReduxStore &&
+            window.ReduxStore.getState &&
+            window.ReduxStore.getState().scratchGui &&
+            window.ReduxStore.getState().scratchGui.addonUtil &&
+            window.ReduxStore.getState().scratchGui.addonUtil.editorAnimPref === "none");
         const div = document.createElement("div");
         document.body.append(div);
         div.classList.add(confirmStyles.base);
         const box = document.createElement("div");
         div.append(box);
         box.classList.add(confirmStyles.promptBox);
+        if (!shouldAnimate) {
+            div.classList.add(confirmStyles.noAnimation);
+            box.classList.add(confirmStyles.noAnimation);
+        }
         setTimeout(() => {
             div.classList.add(confirmStyles.baseVisible);
             box.classList.add(confirmStyles.promptVisible);

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -40,9 +40,9 @@ $data-primary: hsla(30, 100%, 55%, 1); /* #FF8C1A */
 $pen-primary: hsla(163, 85%, 40%, 1); /* #0FBD8C */
 $pen-transparent: hsla(163, 85%, 40%, 0.25); /* #0FBD8C */
 
-$error-primary: hsla(30, 100%, 55%, 1); /* #FF8C1A */
-$error-light: hsla(30, 100%, 70%, 1); /* #FFB366 */
-$error-transparent: hsla(30, 100%, 55%, 0.25); /* #FF8C1A */
+$error-primary: hsla(10, 100%, 55%, 1); /* #FF8C1A */
+$error-light: hsla(10, 100%, 70%, 1); /* #FFB366 */
+$error-transparent: hsla(10, 100%, 55%, 0.25); /* #FF8C1A */
 
 $extensions-primary: hsla(194, 100%, 50%, 1);
 $extensions-tertiary: hsla(203, 100%, 39%, 1);

--- a/src/css/confirm-dialog.css
+++ b/src/css/confirm-dialog.css
@@ -16,6 +16,10 @@
     background-color: #333a;
 }
 
+.noAnimation {
+    transition: opacity 0s linear, transform 0s linear !important;
+}
+
 .baseVisible {
     opacity: 1;
 }

--- a/src/reducers/addon-util.js
+++ b/src/reducers/addon-util.js
@@ -1,9 +1,10 @@
 const SET_SOUND_EDITOR_WAVEFORM_CHUNK_SIZE = 'scratch-gui/addon-util/SET_SOUND_EDITOR_WAVEFORM_CHUNK_SIZE';
-const SET_EDITOR_ANIM_PREF = 'scratch-gui/addon-util/SET_EDITOR_ANIM_PREF';
+const SET_REACTIVE_SETTINGS = 'scratch-gui/addon-util/SET_REACTIVE_SETTINGS';
 
 const initialState = {
     soundEditorWaveformChunkSize: 1024,
-    editorAnimPref: 'default'
+    editorAnimPref: 'none',
+    editorDeleteAnim: 'shrink'
 };
 
 const reducer = function (state, action) {
@@ -13,9 +14,10 @@ const reducer = function (state, action) {
             return {
                 soundEditorWaveformChunkSize: action.chunkSize
             };
-        case SET_EDITOR_ANIM_PREF:
+        case SET_REACTIVE_SETTINGS:
             return {
-                editorAnimPref: action.animPref
+                editorAnimPref: action.animPref,
+                editorDeleteAnim: action.deleteAnim
             };
         default:
             return state;
@@ -29,16 +31,18 @@ const setSoundEditorWaveformChunkSize = function (chunkSize) {
     };
 };
 
-const setEditorAnimPref = function (preference) {
+const setReactiveSettings = function (settings) {
     return {
-        type: SET_EDITOR_ANIM_PREF,
-        animPref: preference
+        type: SET_REACTIVE_SETTINGS,
+        settings: settings
     };
 };
+
+
 
 export {
     reducer as default,
     initialState as addonUtilInitialState,
     setSoundEditorWaveformChunkSize,
-    setEditorAnimPref
+    setReactiveSettings
 };


### PR DESCRIPTION
I have fully fleshed out my unfinished work from the previous PR. Modals that were previously broken now fully animate.

Earlier today I renamed Animation Types to Reactive. Now, I have split Reactive off into Reactive and Reactive: Animations. Reactive is just default things around the editor that react when you hover or press them. I figure this is okay since they barely move and don't move fast. If you want me to add an option to fully disable them, however, just tell me.

Reactive: Animations is more vigorous movement and obvious animations. I haven't animated any new items in this update, but I have updated an existing one with a new animation type. The sprite deletion animation can now be configured to fly out as opposed to the original shrink animation.

I have mostly just added reactiveness to the following things:
- Menu bar items
- Context menu items
- Project controls
- Category icons

And I have made some small design changes to support this reactiveness and make it feel fluid. Those being: 

I made the context menu items shrink and turn round on hover
![image](https://github.com/user-attachments/assets/5b5faf31-1bb5-416e-b94a-793826f430a1)

and,

I made the menu bar items grow and turn round on hover
![image](https://github.com/user-attachments/assets/5cd0ae57-678c-465b-a1cd-30e3e9389184)
