### PR TITLE
avoid dragging icon from the delete button

### DIFF
--- a/src/components/delete-button/delete-button.css
+++ b/src/components/delete-button/delete-button.css
@@ -32,5 +32,6 @@
     position: relative;
     margin: 0.25rem;
     user-select: none;
+    pointer-events: none !important;
     transform-origin: 50%;
 }

--- a/src/components/delete-button/delete-button.css
+++ b/src/components/delete-button/delete-button.css
@@ -32,6 +32,5 @@
     position: relative;
     margin: 0.25rem;
     user-select: none;
-    pointer-events: none !important;
     transform-origin: 50%;
 }

--- a/src/components/delete-button/delete-button.jsx
+++ b/src/components/delete-button/delete-button.jsx
@@ -20,6 +20,7 @@ const DeleteButton = props => (
             <img
                 className={styles.deleteIcon}
                 src={deleteIcon}
+                draggable="false"
             />
         </div>
     </div>


### PR DESCRIPTION
this adds a line where it sets pointer-events to none on delete-icon, so the image in the delete button shouldn't be able to be dragged accidentally