### PR TITLE
Update .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 tasks:
     - name: Install and build
       init: npm i -g pnpm && pnpm up && pnpm i --shamefully-hoist
-      command: npm run start
+      command: NODE_OPTIONS=--openssl-legacy-provider npm run start
 
 ports:
      - port: 3000


### PR DESCRIPTION
# I have confirmed that this method works on Gitpod.
Error before the fix:
```
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from /workspace/penguinmod-s4s/build
ℹ ｢wds｣: 404s will fallback to /index.html
10% building 7/8 modules 1 active ...2_webpack@4.46.0/node_modules/webpack-dev-server/client/index.js?http://0.0.0.0:3000node:internal/crypto/hash:79
  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:79:19)
    at Object.createHash (node:crypto:139:10)
    at module.exports (/workspace/penguinmod-s4s/node_modules/.pnpm/webpack@4.46.0_webpack-cli@3.3.12/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/workspace/penguinmod-s4s/node_modules/.pnpm/webpack@4.46.0_webpack-cli@3.3.12/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/workspace/penguinmod-s4s/node_modules/.pnpm/webpack@4.46.0_webpack-cli@3.3.12/node_modules/webpack/lib/NormalModule.js:471:10)
    at /workspace/penguinmod-s4s/node_modules/.pnpm/webpack@4.46.0_webpack-cli@3.3.12/node_modules/webpack/lib/NormalModule.js:503:5
    at /workspace/penguinmod-s4s/node_modules/.pnpm/webpack@4.46.0_webpack-cli@3.3.12/node_modules/webpack/lib/NormalModule.js:358:12
    at /workspace/penguinmod-s4s/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/workspace/penguinmod-s4s/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/workspace/penguinmod-s4s/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/workspace/penguinmod-s4s/node_modules/.pnpm/enhanced-resolve@4.5.0/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /workspace/penguinmod-s4s/node_modules/.pnpm/enhanced-resolve@4.5.0/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /workspace/penguinmod-s4s/node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read/context:68:3) {
  opensslErrorStack: [
    'error:03000086:digital envelope routines::initialization error',
    'error:0308010C:digital envelope routines::unsupported'
  ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v22.16.0
```