### PR TITLE
hide turn around block

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -129,7 +129,6 @@ const motion = function (isInitialSetup, isStage, targetId) {
                 </shadow>
             </value>
         </block>
-        <block type="motion_turnaround"/>
         ${blockSeparator}
         <block type="motion_changexby">
             <value name="DX">


### PR DESCRIPTION
why did this even exist in the first place... mfw turn 180 degrees
<img width="301" height="183" alt="image" src="https://github.com/user-attachments/assets/bc0dc150-801d-44fb-a850-ece0f1fea2ec" />
