### PR TITLE
URI Encode project title

### DIFF
--- a/src/components/menu-bar/share-button.jsx
+++ b/src/components/menu-bar/share-button.jsx
@@ -147,8 +147,9 @@ class ShareButton extends React.Component {
                 editPiece = `&id=${id}`;
             }
 
+            const projectTitle = encodeURIComponent(this.props.projectTitle);
             const url = location.origin;
-            window.open(`https://penguinmod.com/${targetPage}?name=${this.props.projectTitle}${editPiece}${remixPiece}&external=${url}`, '_blank');
+            window.open(`https://penguinmod.com/${targetPage}?name=${projectTitle}${editPiece}${remixPiece}&external=${url}`, '_blank');
         });
     }
     render() {


### PR DESCRIPTION
Fixes https://github.com/PenguinMod/PenguinMod-Home/issues/415

runs `encodeURIComponent` on the project title to make sure the project title is properly encoded upon arrival.