### PR TITLE
Update custom-block-shape addon: Add superellipsed reporters

### DIFF
--- a/src/addons/addons/custom-block-shape/_manifest_entry.js
+++ b/src/addons/addons/custom-block-shape/_manifest_entry.js
@@ -72,6 +72,22 @@ const manifest = {
       "default": 100,
       "max": 200
     },
+    {
+      "dynamic": true,
+      "name": "Superellipse reporters (corner smoothing)",
+      "id": "superellipseReporters",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "dynamic": true,
+      "name": "Superellipse strength (50-150%)",
+      "id": "superellipseFactor",
+      "type": "integer",
+      "min": 50,
+      "default": 100,
+      "max": 150,
+    }
   ],
   "presets": [
     {

--- a/src/addons/addons/custom-block-shape/_manifest_entry.js
+++ b/src/addons/addons/custom-block-shape/_manifest_entry.js
@@ -33,6 +33,11 @@ const manifest = {
       "type": "notice",
       "text": "Decreasing the padding size is only visible to you, so when your projects are viewed by other users, your scripts may overlap.",
       "id": "paddingWarning"
+    },
+    {
+      "type": "notice",
+      "text": "Higher superellipse strength values cause the reporter shape to become more square, and can cause the block to be confused with other output types like Array.",
+      "id": "confusionWarning"
     }
   ],
   "settings": [

--- a/src/addons/addons/custom-block-shape/userscript.js
+++ b/src/addons/addons/custom-block-shape/userscript.js
@@ -6,8 +6,110 @@ export default async function ({ addon, console }) {
     var vm = addon.tab.traps.vm;
 
     const ogFieldImageInit = BlocklyInstance.FieldImage.prototype.init;
+    const ogRender = BlockSvg.prototype.render;
 
     const { GRID_UNIT } = BlockSvg;
+
+    // gets the superellipse strength setting
+    function getSuperellipseHandleFactor() {
+      const setting = addon.settings.get("superellipseFactor") || 100;
+      // normalize the setting to values we can use
+      return 0.55 + ((setting - 50) / 100) * 0.30;
+    }
+
+    // arc to superellipse
+    function convertRoundPathToSuperellipse(pathString) {
+      // path parsing stuff (thanks stackoverflow)
+      const commands = pathString.match(/[mMhHvVlLcCaAzZ][^mMhHvVlLcCaAzZ]*/g);
+      if (!commands) return pathString;
+      
+      let currentX = 0;
+      let currentY = 0;
+      let newCommands = [];
+      
+      for (let cmd of commands) {
+        const type = cmd[0];
+        const args = cmd.slice(1).trim().split(/[\s,]+/).filter(s => s).map(parseFloat);
+        
+        if (type === 'm' || type === 'M') {
+          if (type === 'm') {
+            currentX += args[0] || 0;
+            currentY += args[1] || 0;
+          } else {
+            currentX = args[0] || 0;
+            currentY = args[1] || 0;
+          }
+          newCommands.push(cmd);
+        } else if (type === 'H') {
+          currentX = args[0];
+          newCommands.push(cmd);
+        } else if (type === 'h') {
+          currentX += args[0];
+          newCommands.push(cmd);
+        } else if (type === 'V') {
+          currentY = args[0];
+          newCommands.push(cmd);
+        } else if (type === 'v') {
+          currentY += args[0];
+          newCommands.push(cmd);
+        } else if (type === 'a' || type === 'A') {
+          const rx = args[0];
+          const ry = args[1];
+          const dx = args[5];
+          const dy = args[6];
+          
+          const r = rx;
+          const handle = r * getSuperellipseHandleFactor();
+          
+          if (dx === 0 && dy > 0) {
+            const topCurve = `C ${currentX + handle} ${currentY}, ${currentX + r} ${currentY + (r - handle)}, ${currentX + r} ${currentY + r}`;
+            const bottomCurve = `C ${currentX + r} ${currentY + r + handle}, ${currentX + handle} ${currentY + 2 * r}, ${currentX} ${currentY + 2 * r}`;
+            
+            newCommands.push(topCurve);
+            newCommands.push(bottomCurve);
+            
+            currentY += 2 * r;
+          } else if (dx === 0 && dy < 0) {
+            const bottomCurve = `C ${currentX - handle} ${currentY}, ${currentX - r} ${currentY - (r - handle)}, ${currentX - r} ${currentY - r}`;
+            const topCurve = `C ${currentX - r} ${currentY - r - handle}, ${currentX - handle} ${currentY - 2 * r}, ${currentX} ${currentY - 2 * r}`;
+            
+            newCommands.push(bottomCurve);
+            newCommands.push(topCurve);
+            
+            currentY -= 2 * r;
+          } else {
+            newCommands.push(cmd);
+          }
+        } else {
+          newCommands.push(cmd);
+        }
+      }
+      
+      return newCommands.join(' ');
+    }
+
+    BlockSvg.prototype.render = function(opt_bubble) {
+      const result = ogRender.call(this, opt_bubble);
+      
+      if (addon.settings.get("superellipseReporters")) {
+        if (this.outputConnection && !this.previousConnection && !this.nextConnection) {
+          const pathElement = this.svgPath_;
+          if (pathElement) {
+            const currentPath = pathElement.getAttribute('d');
+            // if it contains an "a" arc command
+            if (currentPath && currentPath.includes('a ')) {
+              const radiusMatch = currentPath.match(/a\s+([\d.]+)/);
+              const radius = radiusMatch ? parseFloat(radiusMatch[1]) : 20;
+              
+              const newPath = convertRoundPathToSuperellipse(currentPath);
+              pathElement.setAttribute('d', newPath);
+            }
+          }
+        }
+      }
+      
+      return result;
+    };
 
     function path2SegmentList(path) {
       const cmds = structuredClone(BlockSvg.CUSTOM_NOTCH_UTIL.supportedCommands);
@@ -57,6 +159,19 @@ export default async function ({ addon, console }) {
           return val *= i % 2 ? scaleX : scaleY;
         });
       }).flat().join(" ");
+    }
+
+    // reporters use arcs, but superellipses are cooler and need cool bezier curves
+    function arcToSuperellipseBezier(rx, ry, multiplier) {
+      const handle = SUPERELLIPSE_MAGIC * SUPERELLIPSE_FACTOR;
+      const cx1 = rx * handle;
+      const cy1 = 0;
+      const cx2 = rx;
+      const cy2 = ry * (1 - handle);
+      const x = rx;
+      const y = ry;
+      
+      return `c ${cx1} ${cy1} ${cx2} ${cy2} ${x} ${y}`;
     }
 
     function updateAllBlocks() {
@@ -170,6 +285,7 @@ export default async function ({ addon, console }) {
         "," +
         -4 * GRID_UNIT * multiplier +
         " z";
+
       BlockSvg.INPUT_SHAPE_ROUND_WIDTH = 12 * GRID_UNIT * multiplier;
       BlockSvg.INPUT_SHAPE_ROUND =
         "M " +


### PR DESCRIPTION
This PR adds an option to the Customizable block shape addon, allowing you to enable superellipsed roundness on reporters.

Superellipsed roundness is really cool. It's what makes your iPhone icons feel very natural, as it prevents any sudden jumps in curvature on rounded rectangles. 

The science behind it is really cool but I'll spare you the reading and show you this graphic:
<img width="2000" height="849" alt="image" src="https://github.com/user-attachments/assets/6a3e6f93-a9c6-485c-830e-a74c63fbfa66" />

On the left one (which does not use superellipsed rounding), the area where it has no comb means there is no curvature. The curvature comb literally jumps to 0 infinitely steeply, creating an unnatural edge.

If you know what a squircle is, you've seen some level of superellipse roundness. This addon essentially makes reporters look kind of like squircles.

The superellipse strength value can go from 50% (off) to 150% (max).

You can see the difference between values here:

OFF
<img width="254" height="215" alt="image" src="https://github.com/user-attachments/assets/3c25cead-9d93-45a0-94cb-0ae2bcb7aefa" />


70%
<img width="241" height="188" alt="image" src="https://github.com/user-attachments/assets/4d97c9c8-0698-4f46-bb21-632e5469d667" />


100% (default)
<img width="277" height="171" alt="image" src="https://github.com/user-attachments/assets/06b9a513-8111-4334-8637-cb1ecdb32d7e" />


150%
<img width="238" height="169" alt="image" src="https://github.com/user-attachments/assets/4b87210a-8e49-4b8e-b548-508ce30be704" />

To make the difference clearer, here's off, and max right below:
<img width="600" height="98" alt="image" src="https://github.com/user-attachments/assets/f496d5a6-4618-4a2e-bbf4-b72e9b7c62ae" />
<img width="602" height="88" alt="image" src="https://github.com/user-attachments/assets/299ea6a8-cf62-4be5-a4f5-c8f04d417faa" />
