### PR TITLE
Add currently playing sounds

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -554,6 +554,7 @@ const sound = function (isInitialSetup, isStage, targetId, soundName) {
             </value>
         </block>
         <block id="${targetId}_volume" type="sound_volume"/>
+        <block id="${targetId}_currentlyPlayingSounds" type="sound_currentlyPlayingSounds" />
         ${categorySeparator}
     </category>
     `;

--- a/src/lib/opcode-labels.js
+++ b/src/lib/opcode-labels.js
@@ -170,6 +170,11 @@ const messages = defineMessages({
         description: 'Label for the tempo monitor when shown on the stage',
         id: 'gui.opcodeLabels.tempo'
     },
+    sound_currentlyPlayingSounds: {
+        defaultMessage: 'currently playing sounds',
+        description: 'Label for the currently playing sounds monitor when shown on the stage',
+        id: 'gui.opcodeLabels.currentlyPlayingSounds'
+    },
 
     // Sensing
     sensing_answer: {
@@ -328,6 +333,7 @@ class OpcodeLabels {
             sound_volume: {category: 'sound'},
             sound_getEffectValue: {category: 'sound'},
             sound_tempo: {category: 'sound'},
+            sound_currentlyPlayingSounds: {category: 'sound' },
 
             // Sensing
             sensing_answer: {category: 'sensing'},
@@ -417,6 +423,7 @@ class OpcodeLabels {
             }
             return this._translator(messages.sound_getEffectValue);
         };
+        this._opcodeMap.sound_currentlyPlayingSounds.labelFn = () => this._translator(messages.sound_currentlyPlayingSounds);
 
         // Sensing
         this._opcodeMap.sensing_answer.labelFn = () => this._translator(messages.sensing_answer);


### PR DESCRIPTION
Resolves https://github.com/PenguinMod/PenguinMod-Home/issues/471

The adds a new block to the sound category which lists out all sounds which are currently playing. Primary point of this PR is that this block looked really easy to implement, so I implemented it.

## Related

* https://github.com/PenguinMod/PenguinMod-Vm/pull/171
* https://github.com/PenguinMod/PenguinMod-Blocks/pull/42