### PR TITLE
[Not sketchy] Fix name of stack trace in log capture

### DIFF
--- a/src/lib/pm-log-capture.js
+++ b/src/lib/pm-log-capture.js
@@ -199,6 +199,7 @@ window.addEventListener('unhandledrejection', e => push('promiseError', String(e
 class StackTrace extends Error {
     constructor() {
         super('');
+        this.name = 'StackTrace';
         if (this.stack.split('\n', 2)[0].includes('@')) {
             this.stack = this.stack
                 .split('\n')


### PR DESCRIPTION
### Resolves

Fixes the misleading `Error:` text in all log captures.

<img width="312" height="123" alt="image" src="https://github.com/user-attachments/assets/e79a2bc3-3425-48ca-84ec-f5fac37c8d4f" />

### Proposed Changes

Replaces the `Error:` text in log captures with `StackTrace:`. I am like 80% sure I did this right.

<img width="320" height="52" alt="image" src="https://github.com/user-attachments/assets/200121d7-8d9c-4d2b-b1c2-9e64d68ce3c7" />

_(I don't know how to properly test it, so in the image above I just copy-pasted the `StackTrace` class with my change and threw an error)_

### Reason for Changes

This makes the log captures less misleading.

### Test Coverage

> _Please show how you have added tests to cover your changes_

I didn't 🤯

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

#### I have literally no idea how to test this properly so I just threw an error in the console using the modified class

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [x] Firefox 
 * [x] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
